### PR TITLE
Fix tests to not use the "log" prefix

### DIFF
--- a/console_test.go
+++ b/console_test.go
@@ -2,19 +2,17 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package log_test
+package log
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/go-ozzo/ozzo-log"
 )
 
 func TestNewConsoleTarget(t *testing.T) {
-	target := log.NewConsoleTarget()
-	if target.MaxLevel != log.LevelDebug {
-		t.Errorf("ConsoleTarget.MaxLevel = %v, expected %v", target.MaxLevel, log.LevelDebug)
+	target := NewConsoleTarget()
+	if target.MaxLevel != LevelDebug {
+		t.Errorf("ConsoleTarget.MaxLevel = %v, expected %v", target.MaxLevel, LevelDebug)
 	}
 	if target.ColorMode != true {
 		t.Errorf("ConsoleTarget.ColorMode = %v, expected %v", target.ColorMode, true)
@@ -35,10 +33,10 @@ func (m *MemoryWriter) Write(p []byte) (int, error) {
 
 type ConsoleTargetMock struct {
 	done chan bool
-	*log.ConsoleTarget
+	*ConsoleTarget
 }
 
-func (t *ConsoleTargetMock) Process(e *log.Entry) {
+func (t *ConsoleTargetMock) Process(e *Entry) {
 	t.ConsoleTarget.Process(e)
 	if e == nil {
 		t.done <- true
@@ -46,10 +44,10 @@ func (t *ConsoleTargetMock) Process(e *log.Entry) {
 }
 
 func TestConsoleTarget(t *testing.T) {
-	logger := log.NewLogger()
+	logger := NewLogger()
 	target := &ConsoleTargetMock{
 		done:          make(chan bool, 0),
-		ConsoleTarget: log.NewConsoleTarget(),
+		ConsoleTarget: NewConsoleTarget(),
 	}
 	writer := &MemoryWriter{}
 	target.Writer = writer

--- a/example_test.go
+++ b/example_test.go
@@ -2,14 +2,12 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package log_test
-
-import "github.com/go-ozzo/ozzo-log"
+package log
 
 func ExampleLogger_Error() {
-	logger := log.NewLogger()
+	logger := NewLogger()
 
-	logger.Targets = append(logger.Targets, log.NewConsoleTarget())
+	logger.Targets = append(logger.Targets, NewConsoleTarget())
 
 	logger.Open()
 
@@ -20,10 +18,10 @@ func ExampleLogger_Error() {
 }
 
 func ExampleNewConsoleTarget() {
-	logger := log.NewLogger()
+	logger := NewLogger()
 
 	// creates a ConsoleTarget with color mode being disabled
-	target := log.NewConsoleTarget()
+	target := NewConsoleTarget()
 	target.ColorMode = false
 
 	logger.Targets = append(logger.Targets, target)
@@ -34,10 +32,10 @@ func ExampleNewConsoleTarget() {
 }
 
 func ExampleNewNetworkTarget() {
-	logger := log.NewLogger()
+	logger := NewLogger()
 
 	// creates a NetworkTarget which uses tcp network and address :10234
-	target := log.NewNetworkTarget()
+	target := NewNetworkTarget()
 	target.Network = "tcp"
 	target.Address = ":10234"
 
@@ -49,10 +47,10 @@ func ExampleNewNetworkTarget() {
 }
 
 func ExampleNewMailTarget() {
-	logger := log.NewLogger()
+	logger := NewLogger()
 
 	// creates a MailTarget which sends emails to admin@example.com
-	target := log.NewMailTarget()
+	target := NewMailTarget()
 	target.Host = "smtp.example.com"
 	target.Username = "foo"
 	target.Password = "bar"
@@ -68,10 +66,10 @@ func ExampleNewMailTarget() {
 }
 
 func ExampleNewFileTarget() {
-	logger := log.NewLogger()
+	logger := NewLogger()
 
 	// creates a FileTarget which keeps log messages in the app.log file
-	target := log.NewFileTarget()
+	target := NewFileTarget()
 	target.FileName = "app.log"
 
 	logger.Targets = append(logger.Targets, target)

--- a/file_test.go
+++ b/file_test.go
@@ -2,21 +2,19 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package log_test
+package log
 
 import (
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/go-ozzo/ozzo-log"
 )
 
 func TestNewFileTarget(t *testing.T) {
-	target := log.NewFileTarget()
-	if target.MaxLevel != log.LevelDebug {
-		t.Errorf("NewFileTarget.MaxLevel = %v, expected %v", target.MaxLevel, log.LevelDebug)
+	target := NewFileTarget()
+	if target.MaxLevel != LevelDebug {
+		t.Errorf("NewFileTarget.MaxLevel = %v, expected %v", target.MaxLevel, LevelDebug)
 	}
 	if target.Rotate != true {
 		t.Errorf("NewFileTarget.Rotate = %v, expected %v", target.Rotate, true)
@@ -33,8 +31,8 @@ func TestFileTarget(t *testing.T) {
 	logFile := "app.log"
 	os.Remove(logFile)
 
-	logger := log.NewLogger()
-	target := log.NewFileTarget()
+	logger := NewLogger()
+	target := NewFileTarget()
 	target.FileName = logFile
 	target.Categories = []string{"system.*"}
 	logger.Targets = append(logger.Targets, target)

--- a/filter_test.go
+++ b/filter_test.go
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package log_test
+package log
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/go-ozzo/ozzo-log"
 )
 
 func TestFilterAllow(t *testing.T) {
@@ -28,9 +26,9 @@ func TestFilterAllow(t *testing.T) {
 		{[]string{"system.*"}, "system.db", true},
 	}
 	for _, test := range tests {
-		filter := log.Filter{MaxLevel: log.LevelDebug, Categories: test.cats}
+		filter := Filter{MaxLevel: LevelDebug, Categories: test.cats}
 		filter.Init()
-		e := &log.Entry{Category: test.cat}
+		e := &Entry{Category: test.cat}
 		if filter.Allow(e) != test.expected {
 			t.Errorf("filter(%q).Allow(%q) = %v, expected %v", strings.Join(test.cats, ","), test.cat, filter.Allow(e), test.expected)
 		}

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,20 +2,19 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package log_test
+package log
 
 import (
 	"io"
 	"testing"
 
 	"github.com/go-ozzo/ozzo-config"
-	"github.com/go-ozzo/ozzo-log"
 )
 
 func TestNewLogger(t *testing.T) {
-	logger := log.NewLogger()
-	if logger.MaxLevel != log.LevelDebug {
-		t.Errorf("NewLogger().MaxLevel = %v, expected %v", logger.MaxLevel, log.LevelDebug)
+	logger := NewLogger()
+	if logger.MaxLevel != LevelDebug {
+		t.Errorf("NewLogger().MaxLevel = %v, expected %v", logger.MaxLevel, LevelDebug)
 	}
 	if logger.Category != "app" {
 		t.Errorf("NewLogger().Category = %v, expected %v", logger.Category, "app")
@@ -26,10 +25,10 @@ func TestNewLogger(t *testing.T) {
 }
 
 func TestGetLogger(t *testing.T) {
-	formatter := func(*log.Logger, *log.Entry) string {
+	formatter := func(*Logger, *Entry) string {
 		return "test"
 	}
-	logger := log.NewLogger()
+	logger := NewLogger()
 	logger1 := logger.GetLogger("testing")
 	if logger1.Category != "testing" {
 		t.Errorf("logger1.Category = %v, expected %v", logger1.Category, "testing")
@@ -44,7 +43,7 @@ func TestGetLogger(t *testing.T) {
 }
 
 type MemoryTarget struct {
-	entries []*log.Entry
+	entries []*Entry
 	open    bool
 	ready   chan bool
 	Option1 string
@@ -53,11 +52,11 @@ type MemoryTarget struct {
 
 func (m *MemoryTarget) Open(io.Writer) error {
 	m.open = true
-	m.entries = make([]*log.Entry, 0)
+	m.entries = make([]*Entry, 0)
 	return nil
 }
 
-func (m *MemoryTarget) Process(e *log.Entry) {
+func (m *MemoryTarget) Process(e *Entry) {
 	if e == nil {
 		m.ready <- true
 	} else {
@@ -70,7 +69,7 @@ func (t *MemoryTarget) Close() {
 }
 
 func TestLoggerLog(t *testing.T) {
-	logger := log.NewLogger()
+	logger := NewLogger()
 	target := &MemoryTarget{
 		ready: make(chan bool, 0),
 	}
@@ -84,7 +83,7 @@ func TestLoggerLog(t *testing.T) {
 		t.Errorf("target.open = %v, expected %v", target.open, true)
 	}
 
-	logger.Log(log.LevelInfo, "t0: %v", 1)
+	logger.Log(LevelInfo, "t0: %v", 1)
 	logger.Debug("t1: %v", 2)
 	logger.Info("t2")
 	logger.Warning("t3")
@@ -143,13 +142,13 @@ func TestLoggerConfig(t *testing.T) {
 	c.Register("memory2", func() *MemoryTarget {
 		return &MemoryTarget{Option2: true}
 	})
-	logger := log.NewLogger()
+	logger := NewLogger()
 
 	if err := c.Configure(logger, "Logger"); err != nil {
 		t.Errorf("config.Configure(logger): %v", err)
 	}
-	if logger.MaxLevel != log.LevelCritical {
-		t.Errorf("logger.MaxLevel = %v, expected %v", logger.MaxLevel, log.LevelCritical)
+	if logger.MaxLevel != LevelCritical {
+		t.Errorf("logger.MaxLevel = %v, expected %v", logger.MaxLevel, LevelCritical)
 	}
 	if logger.Category != "app2" {
 		t.Errorf("logger.Category = %v, expected %v", logger.Category, "app2")

--- a/mail_test.go
+++ b/mail_test.go
@@ -2,17 +2,15 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package log_test
+package log
 
 import (
 	"testing"
-
-	"github.com/go-ozzo/ozzo-log"
 )
 
 func TestNewMailTarget(t *testing.T) {
-	target := log.NewMailTarget()
-	if target.MaxLevel != log.LevelDebug {
-		t.Errorf("NewMailTarget.MaxLevel = %v, expected %v", target.MaxLevel, log.LevelDebug)
+	target := NewMailTarget()
+	if target.MaxLevel != LevelDebug {
+		t.Errorf("NewMailTarget.MaxLevel = %v, expected %v", target.MaxLevel, LevelDebug)
 	}
 }

--- a/network_test.go
+++ b/network_test.go
@@ -2,20 +2,18 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package log_test
+package log
 
 import (
 	"net"
 	"strings"
 	"testing"
-
-	"github.com/go-ozzo/ozzo-log"
 )
 
 func TestNewNetworkTarget(t *testing.T) {
-	target := log.NewNetworkTarget()
-	if target.MaxLevel != log.LevelDebug {
-		t.Errorf("NetworkTarget.MaxLevel = %v, expected %v", target.MaxLevel, log.LevelDebug)
+	target := NewNetworkTarget()
+	if target.MaxLevel != LevelDebug {
+		t.Errorf("NetworkTarget.MaxLevel = %v, expected %v", target.MaxLevel, LevelDebug)
 	}
 	if !target.Persistent {
 		t.Errorf("NetworkTarget.Persistent should be true, got false")
@@ -60,8 +58,8 @@ func TestNetworkTarget(t *testing.T) {
 		return
 	}
 
-	logger := log.NewLogger()
-	target := log.NewNetworkTarget()
+	logger := NewLogger()
+	target := NewNetworkTarget()
 	target.Network = network
 	target.Address = address
 	target.Categories = []string{"system.*"}


### PR DESCRIPTION
Fix tests to not use the "log" prefix, as it makes impossible for a fork to create tests